### PR TITLE
RK-9600 - use flask-opentracing forked module

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,7 +145,7 @@ def initialize_tracer():
     return config.initialize_tracer()  # also sets opentracing.tracer
 
 
-flask_tracer = FlaskTracer(initialize_tracer, True, app)
+flask_tracer = FlaskTracer(initialize_tracer, True, app, ["remote_addr"])
 
 import rook
 rook.start()

--- a/app.py
+++ b/app.py
@@ -145,7 +145,7 @@ def initialize_tracer():
     return config.initialize_tracer()  # also sets opentracing.tracer
 
 
-flask_tracer = FlaskTracer(initialize_tracer, True, app, ["remote_addr"])
+flask_tracer = FlaskTracer(initialize_tracer, True, app)
 
 import rook
 rook.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rook>=0.1.146
 flask>=1.0,<=2.0
 sentry-sdk[flask]>=0.6.9
-flask-opentracing
+-e git://github.com/Rookout/python-flask.git@7cdfd7ea6370f4dab8e49ab043e4ef57602b85ea#egg=Flask_OpenTracing
 jaeger-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rook>=0.1.146
 flask>=1.0,<=2.0
 sentry-sdk[flask]>=0.6.9
--e git://github.com/Rookout/python-flask.git@7cdfd7ea6370f4dab8e49ab043e4ef57602b85ea#egg=Flask_OpenTracing
+-e git://github.com/Rookout/python-flask.git@1fc8bfa16046a264db1f4a53ff751ee808a2f047#egg=Flask_OpenTracing
 jaeger-client


### PR DESCRIPTION
I forked the flask-openTracing module (https://github.com/opentracing-contrib/python-flask) and pushed a little addition (https://github.com/Rookout/python-flask/commit/79637485c460bfa3865e5a491147a9dd3aeec905).

in this PR, I'm changing our tutorial-python app to use the fork instead of the original repo.

This means the tags our tracing context has will include the user's IP address (retrieved from Flask).
here a screenshot from rookout, notice the remote_addr tag. (in this case localhost, since that's where I tested it)

![image](https://user-images.githubusercontent.com/42871571/121187910-3ae6dc80-c871-11eb-8686-bacccea242aa.png)
