### PR TITLE
RK-9608 - dockerFile // install git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.8-slim
 
+# pip installing the requirements.txt requires git because we're installing a fork
+RUN apt-get -y update
+RUN apt-get -y install git
+
 ARG GIT_COMMIT=unspecified
 ENV ROOKOUT_COMMIT=$GIT_COMMIT
 


### PR DESCRIPTION
in a previous PR (https://github.com/Rookout/tutorial-python/pull/49) I changed the requirements.txt file to include a fork of a module.
after merging, the build of master broke

![image](https://user-images.githubusercontent.com/42871571/121316904-71c0ff00-c912-11eb-9cde-4573726c7162.png)

turns out that installing a requirement from a fork requires git installed. so I added it to the dockerfile.