### PR TITLE
RK-9617 - add ip forwarding to the tracing span context

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rook>=0.1.146
 flask>=1.0,<=2.0
 sentry-sdk[flask]>=0.6.9
--e git://github.com/Rookout/python-flask.git@1fc8bfa16046a264db1f4a53ff751ee808a2f047#egg=Flask_OpenTracing
+-e git://github.com/Rookout/python-flask.git@bbd0c68f4301036b684cbe688709767c571996eb#egg=Flask_OpenTracing
 jaeger-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rook>=0.1.146
 flask>=1.0,<=2.0
 sentry-sdk[flask]>=0.6.9
--e git://github.com/Rookout/python-flask.git@bbd0c68f4301036b684cbe688709767c571996eb#egg=Flask_OpenTracing
+-e git://github.com/Rookout/python-flask.git@25055a45265963bb1d36a4b90c3b94d9388d29a9#egg=Flask_OpenTracing
 jaeger-client


### PR DESCRIPTION
i added this change to the flask-openTracing fork we're using (https://github.com/Rookout/python-flask/pull/1, and than this fix https://github.com/Rookout/python-flask/commit/25055a45265963bb1d36a4b90c3b94d9388d29a9 (optional chaning)
so I'm updating tutorial-python to use the latest commit of the fork.

The change means we're adding to the span context the HTTP_X_FORWARDED_FOR header of the http request, which will allow us to know the actual user IP, instead of the Kubernetes ingress, or any other proxy.