### PR TITLE
RK-9618 - Update flask openTracing version (our fork)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rook>=0.1.146
 flask>=1.0,<=2.0
 sentry-sdk[flask]>=0.6.9
--e git://github.com/Rookout/python-flask.git@25055a45265963bb1d36a4b90c3b94d9388d29a9#egg=Flask_OpenTracing
+-e git://github.com/Rookout/python-flask.git@8cf5c2cc2c390c948bddd1c4b49cfb572e0ee56e#egg=Flask_OpenTracing
 jaeger-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rook>=0.1.146
 flask>=1.0,<=2.0
 sentry-sdk[flask]>=0.6.9
--e git://github.com/Rookout/python-flask.git@8cf5c2cc2c390c948bddd1c4b49cfb572e0ee56e#egg=Flask_OpenTracing
+-e git://github.com/Rookout/python-flask.git@f71df9bdb816894c3f3f96c3f0e3a3eacdf59444#egg=Flask_OpenTracing
 jaeger-client


### PR DESCRIPTION
following bugfix in the fork - https://github.com/Rookout/python-flask/pull/2/files

this time more properly tested