### PR TITLE
RK-11301 - change git protocol to https due to github deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rook>=0.1.160
 flask>=1.0,<=2.0
 sentry-sdk[flask]>=0.6.9
--e git://github.com/Rookout/python-flask.git@e56318f9c84978ecdaeaaff4aa819dc86f5509c7#egg=Flask_OpenTracing
+-e https://github.com/Rookout/python-flask.git@e56318f9c84978ecdaeaaff4aa819dc86f5509c7#egg=Flask_OpenTracing
 jaeger-client


### PR DESCRIPTION
Getting this error in CI:
```
Cloning git://github.com/Rookout/python-flask.git (to revision e56318f9c84978ecdaeaaff4aa819dc86f5509c7) to ./src/flask-opentracing
  Running command git clone -q git://github.com/Rookout/python-flask.git /app/src/flask-opentracing
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
See this:
https://github.blog/2021-09-01-improving-git-protocol-security-github/